### PR TITLE
add nix flake as a dev shell

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1701282334,
+        "narHash": "sha256-MxCVrXY6v4QmfTwIysjjaX0XUhqBbxTWWB4HXtDYsdk=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "057f9aecfb71c4437d2b27d3323df7f93c010b7e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "23.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "utils": "utils"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -10,21 +10,16 @@
         utils.lib.eachDefaultSystem (system:
             let 
                 pkgs = import nixpkgs { inherit system; };
-            in 
+            in with pkgs;
             {
-                packages = {
-                    default = pkgs.stdenv.mkDerivation {
-                        name = "twt-circle";
-                        src = ./.;   
+                devShells = {
+                    default = mkShell {
                         buildInputs = [
-                            pkgs.git
-                            pkgs.nodejs_18
+                            nodejs
                         ];
 
-                        builder = ./setup.sh; 
-
-                        installPhase = ''
-                            echo $out
+                        shellHook = '' 
+                            npm install
                         '';
                     };
                 };

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,33 @@
+{
+    description = "sankalp's twitter circle";
+    
+    inputs = {
+        nixpkgs.url = "github:nixos/nixpkgs/23.11";
+        utils.url = "github:numtide/flake-utils";
+    };
+
+    outputs = { self, utils, nixpkgs }:
+        utils.lib.eachDefaultSystem (system:
+            let 
+                pkgs = import nixpkgs { inherit system; };
+            in 
+            {
+                packages = {
+                    default = pkgs.stdenv.mkDerivation {
+                        name = "twt-circle";
+                        src = ./.;   
+                        buildInputs = [
+                            pkgs.git
+                            pkgs.nodejs_18
+                        ];
+
+                        builder = ./setup.sh; 
+
+                        installPhase = ''
+                            echo $out
+                        '';
+                    };
+                };
+            }
+        );
+}


### PR DESCRIPTION
Hello! This PR introduces a Nix flake as a development shell option for Nix users with flakes enabled. 

To enter the dev shell, simply run
```
nix develop
```